### PR TITLE
Add method to get Forge versions for specific Minecraft version

### DIFF
--- a/CmlLib.Core.Installer.Forge/CmlLib.Core.Installer.Forge.csproj
+++ b/CmlLib.Core.Installer.Forge/CmlLib.Core.Installer.Forge.csproj
@@ -25,7 +25,6 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="CmlLib.Core" Version="4.0.0-beta.2" />
       <PackageReference Include="HtmlAgilityPack" Version="1.11.48" />
     </ItemGroup>
 
@@ -43,5 +42,9 @@
         <None Include="../icon.png" Pack="true" Visible="false" PackagePath="" />
         <None Include="../README.md" Pack="true" Visible="false" PackagePath="" />
         <None Include="FodyWeavers.xsd" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\CmlLib.ExtendedCore\src\CmlLib.Core.csproj" />
     </ItemGroup>
 </Project>

--- a/CmlLib.Core.Installer.Forge/CmlLib.Core.Installer.Forge.csproj
+++ b/CmlLib.Core.Installer.Forge/CmlLib.Core.Installer.Forge.csproj
@@ -25,6 +25,7 @@
     </PropertyGroup>
     
     <ItemGroup>
+      <PackageReference Include="CmlLib.Core" Version="4.0.0-beta.2" />
       <PackageReference Include="HtmlAgilityPack" Version="1.11.48" />
     </ItemGroup>
 
@@ -42,9 +43,5 @@
         <None Include="../icon.png" Pack="true" Visible="false" PackagePath="" />
         <None Include="../README.md" Pack="true" Visible="false" PackagePath="" />
         <None Include="FodyWeavers.xsd" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\CmlLib.ExtendedCore\src\CmlLib.Core.csproj" />
     </ItemGroup>
 </Project>

--- a/CmlLib.Core.Installer.Forge/ForgeInstaller.cs
+++ b/CmlLib.Core.Installer.Forge/ForgeInstaller.cs
@@ -75,7 +75,7 @@ public class ForgeInstaller
             options.JavaPath = getJavaPath(version);
 
         await installer.Install(_launcher.MinecraftPath, _launcher.GameInstaller, options);
-        // showAd();
+        showAd();
         await _launcher.GetAllVersionsAsync();
         return installer.VersionName;
     }

--- a/CmlLib.Core.Installer.Forge/ForgeInstaller.cs
+++ b/CmlLib.Core.Installer.Forge/ForgeInstaller.cs
@@ -38,6 +38,11 @@ public class ForgeInstaller
         return await Install(bestVersion, options);
     }
 
+    public Task<IEnumerable<ForgeVersion>> GetForgeVersions(string mcVersion)
+    {
+        return _versionLoader.GetForgeVersions(mcVersion);
+    }
+
     public Task<string> Install(string mcVersion, string forgeVersion) =>
         Install(mcVersion, forgeVersion, new ForgeInstallOptions());
 
@@ -62,8 +67,8 @@ public class ForgeInstaller
             return installer.VersionName;
 
         var version = await checkAndDownloadVanillaVersion(
-            forgeVersion.MinecraftVersionName, 
-            options.FileProgress, 
+            forgeVersion.MinecraftVersionName,
+            options.FileProgress,
             options.ByteProgress);
 
         if (string.IsNullOrEmpty(options.JavaPath))
@@ -105,6 +110,7 @@ public class ForgeInstaller
             javaPath = _launcher.GetDefaultJavaPath();
         if (string.IsNullOrEmpty(javaPath) || !File.Exists(javaPath))
             throw new InvalidOperationException("Cannot find any java binary. Set java binary path");
+
         return javaPath;
     }
 

--- a/CmlLib.Core.Installer.Forge/ForgeInstaller.cs
+++ b/CmlLib.Core.Installer.Forge/ForgeInstaller.cs
@@ -75,7 +75,7 @@ public class ForgeInstaller
             options.JavaPath = getJavaPath(version);
 
         await installer.Install(_launcher.MinecraftPath, _launcher.GameInstaller, options);
-        showAd();
+        // showAd();
         await _launcher.GetAllVersionsAsync();
         return installer.VersionName;
     }


### PR DESCRIPTION
A new public method, `GetForgeVersions`, has been added to the `ForgeInstaller.cs` class. This method returns the available Forge versions for a specific Minecraft version, improving the process of version management and installation.